### PR TITLE
Changed data refererence paths to new reference folder

### DIFF
--- a/scuole/campuses/management/commands/bootstrapcampuses.py
+++ b/scuole/campuses/management/commands/bootstrapcampuses.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
 
         tea_file = os.path.join(
             settings.DATA_FOLDER,
-            'tapr', 'reference', 'campus_reference.csv')
+            'tapr', 'reference', 'campus', 'reference.csv')
 
         with open(tea_file, 'r') as f:
             reader = csv.DictReader(f)

--- a/scuole/districts/management/commands/bootstrapdistricts.py
+++ b/scuole/districts/management/commands/bootstrapdistricts.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
 
         tea_file = os.path.join(
             settings.DATA_FOLDER,
-            'tapr', 'reference', 'district_reference.csv')
+            'tapr', 'reference', 'district', 'reference.csv')
 
         with open(tea_file, 'r') as f:
             reader = csv.DictReader(f)

--- a/scuole/regions/management/commands/bootstrapregions.py
+++ b/scuole/regions/management/commands/bootstrapregions.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
 
         regions_file = os.path.join(
             settings.DATA_FOLDER,
-            'tapr', 'reference', 'reference_reference.csv')
+            'tapr', 'reference', 'region', 'reference.csv')
 
         with open(regions_file, 'r') as f:
             reader = csv.DictReader(f)


### PR DESCRIPTION
References now live in a folder called `references` and will only contain the most recent information rather than referencing a year.
