### PR TITLE
Model translations fixes

### DIFF
--- a/scuole/campuses/models.py
+++ b/scuole/campuses/models.py
@@ -14,6 +14,7 @@ from scuole.counties.models import County
 from scuole.districts.models import District
 from scuole.stats.models import ReferenceBase, SchoolYear, StatsBase
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 
 
 @python_2_unicode_compatible
@@ -138,7 +139,8 @@ class CampusStats(StatsBase, ReferenceBase):
         verbose_name_plural = _('Campus stats')
 
     def __str__(self):
-        return '{0} {1}'.format(self.year.name, self.campus.name)
+        return ugettext('{year_name} {campus_name}').format(year_name=self.year.name,
+                                                            campus_name=self.campus.name)
 
 
 @python_2_unicode_compatible
@@ -146,4 +148,5 @@ class Principal(PersonnelBase):
     campus = models.ForeignKey(Campus, related_name='principals')
 
     def __str__(self):
-        return '{} at {}'.format(self.name, self.campus.name)
+        return ugettext('{principal} at {campus_name}').format(principal=self.name,
+                                                               campus_name=self.campus.name)

--- a/scuole/districts/models.py
+++ b/scuole/districts/models.py
@@ -14,6 +14,7 @@ from scuole.core.models import PersonnelBase
 from scuole.counties.models import County
 from scuole.regions.models import Region
 from scuole.stats.models import ReferenceBase, SchoolYear, StatsBase
+from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -100,4 +101,5 @@ class Superintendent(PersonnelBase):
     district = models.OneToOneField(District, related_name='superintendent_of')
 
     def __str__(self):
-        return '{} at {}'.format(self.name, self.district.name)
+        return ugettext('{superintendent_name} at {district_name}').format(superintendent_name=self.name,
+                                                                           district_name=self.district.name)

--- a/scuole/states/models.py
+++ b/scuole/states/models.py
@@ -9,6 +9,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from scuole.core.models import PersonnelBase
 from scuole.stats.models import SchoolYear, StatsBase
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 
 
 @python_2_unicode_compatible
@@ -40,4 +41,4 @@ class Commissioner(PersonnelBase):
     state = models.OneToOneField(State, related_name='commissioner_of')
 
     def __str__(self):
-        return 'Texas Education Commissioner'
+        return ugettext('Texas Education Commissioner')

--- a/utils/translation_utils.py
+++ b/utils/translation_utils.py
@@ -1,0 +1,14 @@
+from django.utils import six
+from django.utils.functional import lazy
+from django.utils.translation import ugettext as _
+
+
+def _string_format(string, **kwargs):
+    """
+    Lazy variant of string formatting, needed for translations that require string
+    formatting. Based off implementation of Django's string_concat in translation/__init__.py
+    """
+    return _(string).format(**kwargs)
+
+
+string_format = lazy(_string_format, six.text_type)


### PR DESCRIPTION
Models have translations on **str** methods. I'm not sure whether or not model **str** methods need to return a lazily evaluated object or not for django translations to work correctly. We're assuming they do not need to but just in case I have committed a function (string_format) that returns a lazily evaluated object for formatted strings. Even if **str** does not need the function in the future, it could come in handy for other things (like fields or the Meta portion of classes).

@rdmurphy 
@anniedaniel 
