### PR TITLE
Update dependencies, tweak for a few Django 1.9 warnings

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.views import defaults
 from django.views.generic import TemplateView
 
 from scuole.core.views import AboutView, SearchView
@@ -37,8 +38,8 @@ urlpatterns = [
 # Test pages normally not reachable when DEBUG = True
 if settings.DEBUG:
     urlpatterns += [
-        url(r'^400/$', 'django.views.defaults.bad_request'),
-        url(r'^403/$', 'django.views.defaults.permission_denied'),
-        url(r'^404/$', 'django.views.defaults.page_not_found'),
-        url(r'^500/$', 'django.views.defaults.server_error'),
+        url(r'^400/$', defaults.bad_request),
+        url(r'^403/$', defaults.permission_denied),
+        url(r'^404/$', defaults.page_not_found),
+        url(r'^500/$', defaults.server_error),
     ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
-Django==1.8.6
+Django==1.9
 
 dj-database-url==0.3.0
-django-localflavor==1.1
+django-localflavor==1.2
 psycopg2==2.6.1
 pytz==2015.7
 unicode-slugify==0.1.3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,4 +2,4 @@
 
 django-debug-toolbar==1.4
 django-extensions==1.5.9
-ipython==4.0.0
+ipython==4.0.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-gunicorn==19.3.0
+gunicorn==19.4.1
 whitenoise==2.0.6

--- a/scuole/stats/templatetags/stats_tags.py
+++ b/scuole/stats/templatetags/stats_tags.py
@@ -5,6 +5,7 @@ from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.defaultfilters import floatformat
 from django.utils import six
+from django.utils.html import format_html
 
 register = template.Library()
 
@@ -63,15 +64,15 @@ def display_stat(stat, key, value_type=None, value_label=False):
     display_value, display_descriptor = get_value_display(value, value_type)
 
     if value_label and display_descriptor != '$':
-        html = '<span class="metric-value-label"> {}</span>'.format(
-            display_descriptor)
+        html = format_html(
+            '<span class="metric-value-label"> {}</span>', display_descriptor)
         display_descriptor = html
 
     if display_descriptor == '$':
-        output = '{}{}'.format(display_descriptor, display_value)
+        output = format_html('{}{}', display_descriptor, display_value)
     elif display_descriptor == 'years':
-        output = '{} {}'.format(display_value, display_descriptor)
+        output = format_html('{} {}', display_value, display_descriptor)
     else:
-        output = '{}{}'.format(display_value, display_descriptor)
+        output = format_html('{}{}', display_value, display_descriptor)
 
     return output


### PR DESCRIPTION
We aren't live yet — so why not?

The bugs I had to fix were surprisingly few. Didn't like how we used strings in the `urls.py`, which is fair, because Django has been pushing away from that for a while.

Our custom template tags also didn't do anything to guarantee the HTML they pushed out were safe, and Django 1.9 now by default assumes it isn't. Adding `format_html` fixed it.

Also updated dependencies in general.
