### PR TITLE
Dropout paragraph

### DIFF
--- a/scuole/templates/campuses/campus_detail.html
+++ b/scuole/templates/campuses/campus_detail.html
@@ -45,10 +45,10 @@
   {% if stat.avg_act_score_all_students %}The average ACT score was <strong>{{ stat.avg_act_score_all_students }}</strong>.{% endif %}
   {% endif %}
 
-  {% if stat.four_year_graduate_all_students_percent and stat.four_year_graduate_all_students_percent != -1.0 %}
+  {% if stat.four_year_graduate_all_students_percent and stat.four_year_graduate_all_students_percent >= 0 %}
   In the {{ stat.year.name }} class, <strong>{{ stat.four_year_graduate_all_students_percent|floatformat }}%</strong> of students received their high school diplomas on time or earlier.
   {% endif %}
-  {% if stat.dropout_all_students_percent and stat.dropout_all_students_percent != -1.0 %}
+  {% if stat.dropout_all_students_percent and stat.dropout_all_students_percent >= 0 %}
   The dropout rate was <strong>{{ stat.dropout_all_students_percent|floatformat }}%</strong>.</p>
   {% endif %}
 </section>

--- a/scuole/templates/districts/district_detail.html
+++ b/scuole/templates/districts/district_detail.html
@@ -43,11 +43,11 @@
   The average ACT score was <strong>{{ stat.avg_act_score_all_students }}</strong>.
   {% endif %}
 
-  {% if stat.four_year_graduate_all_students_percent and stat.four_year_graduate_all_students_percent != -1.0 %}
+  {% if stat.four_year_graduate_all_students_percent and stat.four_year_graduate_all_students_percent >= 0 %}
   In the {{ stat.year.name }} class, <strong>{{ stat.four_year_graduate_all_students_percent|floatformat }}%</strong> of students received their high school diplomas on time or earlier.
   {% endif %}
 
-  {% if stat.dropout_all_students_percent and stat.dropout_all_students_percent != -1.0 %}
+  {% if stat.dropout_all_students_percent and stat.dropout_all_students_percent >= 0 %}
   The dropout rate was <strong>{{ stat.dropout_all_students_percent|floatformat }}%</strong>.{% endif %}</p>
 </section>
 </div>


### PR DESCRIPTION
Adds conditionals for dropout and college readiness sentences if the data is masked and the rate is `-1%`
Closes #91 

We decided that the dropout sentence is clear enough and that attempting to further clarify would only make it more weird.
Closes #93 
