### PR TITLE
Added email to commissioner

### DIFF
--- a/scuole/states/management/commands/bootstrapstates.py
+++ b/scuole/states/management/commands/bootstrapstates.py
@@ -77,5 +77,6 @@ class Command(BaseCommand):
                 'name': name,
                 'role': commissioner['Role'],
                 'phone_number': commissioner['Phone'],
+                'email': commissioner['Email'],
             }
         )


### PR DESCRIPTION
We have a new commissioner! This also adds an email.

Corresponds to the `new-commissioner` branch in the `scuole-data` repo.

Pull request found here:
https://github.com/texastribune/scuole-data/pull/9
