### PR TITLE
Fix building of canonical URLs

### DIFF
--- a/scuole/templates/base.html
+++ b/scuole/templates/base.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% block meta %}{% include "includes/meta.html" %}{% endblock meta %}
   <title>{% block title %}{% trans "Home" %}{% endblock title %} | {% trans "Texas Public Schools Explorer" %} | {% trans "The Texas Tribune" %}</title>
+  <link rel="canonical" href="https://schools.texastribune.org{{ request.path }}" />
   <script src="https://use.typekit.net/gbr6cnk.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <link rel="stylesheet" href="{% static 'styles/main.css' %}">
@@ -16,7 +17,7 @@
       "@context": "http://schema.org",
       "@type": "{% block schema_type %}NewsArticle{% endblock schema_type %}",
       "headline": "{% block parsely_title %}Home{% endblock parsely_title %} (Public Schools)",
-      "url": "{{ request.build_absolute_uri }}",
+      "url": "https://schools.texastribune.org{{ request.path }}",
       "thumbnailUrl": "http://schools.texastribune.org{% static 'images/facebook-share.jpg' %}",
       "dateCreated": "2015-12-08T06:00:00-06:00",
       "articleSection": "Public Education",

--- a/scuole/templates/includes/meta.html
+++ b/scuole/templates/includes/meta.html
@@ -1,7 +1,7 @@
 <meta name="twitter:card" content="summary_large_image">{% load static from staticfiles %}
   <meta name="twitter:site" content="@texastribune">
   <meta name="twitter:creator" content="@texastribune">
-  <meta property="og:url" content="{{ request.build_absolute_uri }}">
+  <meta property="og:url" content="https://schools.texastribune.org{{ request.path }}">
   <meta property="og:title" content="{% if title %}{{ title }}{% else %}Texas Public Schools Explorer{% endif %}">
   <meta property="og:type" content="article">
   <meta property="article:publisher" content="https://www.facebook.com/texastribune">


### PR DESCRIPTION
#### What's the plan?

Our canonical URLs were being built using `{{ request.build_request_uri }}`, but that's not ideal - it includes query parameters.
#### What's this PR do?

This is a quick fix to build the active URL based on the active `request.path` instead.
#### Why are we doing this? How does it help us?

Our canonical URLs are busted.
#### How should this be manually tested?

Load the app, visit some pages, and see that the canonical URL in `<meta type="og:url"...` and `<link rel="canonical"...` match the current path. Try to add some query parameters to the end of the URL and ensure they don't show.
#### Have automated tests been added?

N/A
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

N/A
#### What are the relevant tickets?

N/A
#### How should this change be communicated to end users?

N/A
#### Next steps?

N/A
#### Smells?

Feels weird to hardcode, but also we shouldn't expect any surprises. Cool with it. It's also going to change the landing page's canonical URL to include a trailing slash. I don't think that's going to be disastrous.
