### PR TITLE
Hook up redirects for shutting down old outcomes

### DIFF
--- a/scuole/cohorts/urls.py
+++ b/scuole/cohorts/urls.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import include, url
 
 from .views import (
+    AcceptCohortRedirectView,
     CohortsLandingView,
     CountyCohortsDetailView,
     RegionCohortsDetailView,
@@ -19,4 +20,5 @@ urlpatterns = [
         RegionCohortsDetailView.as_view(), name='regions'),
     url(r'^counties/(?P<slug>[\w-]+)/$',
         CountyCohortsDetailView.as_view(), name='counties'),
+    url(r'^redirect/', AcceptCohortRedirectView.as_view(), name='redirect'),
 ]


### PR DESCRIPTION
Much like we did with the previous transition of old schools to new schools, we are setting up smart redirects in the `texastribune` project. This means we'll try to get folks to the page they wanted in the old app if we can.

So if you try to visit here: https://www.texastribune.org/education/public-education/8th-grade-cohorts/region/san-angelo/
We'll re-route you to here: https://schools.texastribune.org/outcomes/regions/15/

And if you try to go here: https://www.texastribune.org/education/public-education/8th-grade-cohorts/county/bexar/
We'll bring you here: https://schools.texastribune.org/outcomes/counties/bexar/

If all else fails, you'll go to the landing page for outcomes.