### PR TITLE
Duplicate district bug

### DIFF
--- a/scuole/campuses/views.py
+++ b/scuole/campuses/views.py
@@ -47,15 +47,4 @@ class CampusDetailView(DetailView):
                 DistrictStats, year=latest_year, district=self.object.district)
             context['state'] = get_object_or_404(
                 StateStats, year=latest_year, state__name='TX')
-
-        # context['county'] = get_object_or_404(
-        #     County, name=self.object.county)
-
-        # context['region'] = get_object_or_404(
-        #     District, name=self.object.district)
-
-        # context['latest_county_cohort'] = county_cohorts.latest_cohort(
-        #     county=self.object.county)
-        # context['latest_region_cohort'] = region_cohorts.latest_cohort(
-        #     region=self.object.district.region)
         return context

--- a/scuole/campuses/views.py
+++ b/scuole/campuses/views.py
@@ -47,4 +47,9 @@ class CampusDetailView(DetailView):
                 DistrictStats, year=latest_year, district=self.object.district)
             context['state'] = get_object_or_404(
                 StateStats, year=latest_year, state__name='TX')
+
+        context['latest_county_cohort'] = county_cohorts.latest_cohort(
+            county=self.object.county)
+        context['latest_region_cohort'] = region_cohorts.latest_cohort(
+            region=self.object.district.region)
         return context

--- a/scuole/campuses/views.py
+++ b/scuole/campuses/views.py
@@ -48,14 +48,14 @@ class CampusDetailView(DetailView):
             context['state'] = get_object_or_404(
                 StateStats, year=latest_year, state__name='TX')
 
-        context['county'] = get_object_or_404(
-            County, name=self.object.county)
+        # context['county'] = get_object_or_404(
+        #     County, name=self.object.county)
 
-        context['region'] = get_object_or_404(
-            District, name=self.object.district)
+        # context['region'] = get_object_or_404(
+        #     District, name=self.object.district)
 
-        context['latest_county_cohort'] = county_cohorts.latest_cohort(
-            county=self.object.county)
-        context['latest_region_cohort'] = region_cohorts.latest_cohort(
-            region=self.object.district.region)
+        # context['latest_county_cohort'] = county_cohorts.latest_cohort(
+        #     county=self.object.county)
+        # context['latest_region_cohort'] = region_cohorts.latest_cohort(
+        #     region=self.object.district.region)
         return context


### PR DESCRIPTION
I'm dumb and added some weird things in the views when I was working on cohorts. Turns out they're not doing anything and they're breaking campuses that belong to districts that have non-unique names. The campus URLs for both Northside ISDs, for example, are all broken because they're returning multiple districts. This should fix.