### PR TITLE
Package upgrade fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ django-phonenumber-field = "*"
 phonenumberslite = "*"
 requests = "*"
 django-postgres-copy = "*"
+six = "*"
 
 [dev-packages]
 "django-debug-toolbar" = "*"

--- a/scuole/campuses/views.py
+++ b/scuole/campuses/views.py
@@ -45,6 +45,7 @@ class CampusDetailView(DetailView):
         #         StateStats, year__name=year, state__name="TX"
         #     )
         # else:
+
         latest_year = SchoolYear.objects.first()
 
         context["stat"] = get_object_or_404(

--- a/scuole/campuses/views.py
+++ b/scuole/campuses/views.py
@@ -32,30 +32,30 @@ class CampusDetailView(DetailView):
         region_cohorts = self.region_cohorts_model.objects.filter(
             region=self.object.district.region
         )
-        year = self.kwargs["campus_year"]
+        # year = self.kwargs["campus_year"]
 
-        if year:
-            context["stat"] = get_object_or_404(
-                CampusStats, year__name=year, campus=self.object
-            )
-            context["district"] = get_object_or_404(
-                DistrictStats, year__name=year, district=self.object.district
-            )
-            context["state"] = get_object_or_404(
-                StateStats, year__name=year, state__name="TX"
-            )
-        else:
-            latest_year = SchoolYear.objects.first()
+        # if year:
+        #     context["stat"] = get_object_or_404(
+        #         CampusStats, year__name=year, campus=self.object
+        #     )
+        #     context["district"] = get_object_or_404(
+        #         DistrictStats, year__name=year, district=self.object.district
+        #     )
+        #     context["state"] = get_object_or_404(
+        #         StateStats, year__name=year, state__name="TX"
+        #     )
+        # else:
+        latest_year = SchoolYear.objects.first()
 
-            context["stat"] = get_object_or_404(
-                CampusStats, year=latest_year, campus=self.object
-            )
-            context["district"] = get_object_or_404(
-                DistrictStats, year=latest_year, district=self.object.district
-            )
-            context["state"] = get_object_or_404(
-                StateStats, year=latest_year, state__name="TX"
-            )
+        context["stat"] = get_object_or_404(
+            CampusStats, year=latest_year, campus=self.object
+        )
+        context["district"] = get_object_or_404(
+            DistrictStats, year=latest_year, district=self.object.district
+        )
+        context["state"] = get_object_or_404(
+            StateStats, year=latest_year, state__name="TX"
+        )
 
         context["latest_county_cohort"] = county_cohorts.latest_cohort(
             county=self.object.county

--- a/scuole/states/views.py
+++ b/scuole/states/views.py
@@ -23,8 +23,11 @@ class StateDetailView(DetailView):
         #     context['stat'] = get_object_or_404(
         #         StateStats, year__name=year, state=self.object)
         # else:
+
+        latest_year = SchoolYear.objects.first()
+
         context['stat'] = get_object_or_404(
-            StateStats, year=SchoolYear.objects.first(),
+            StateStats, year=latest_year,
             state=self.object)
 
         context['latest_state_cohort'] = state_cohorts.latest_cohort

--- a/scuole/states/views.py
+++ b/scuole/states/views.py
@@ -17,15 +17,15 @@ class StateDetailView(DetailView):
         context = super(StateDetailView, self).get_context_data(**kwargs)
         state_cohorts = self.state_cohorts_model.objects.all()
 
-        year = self.kwargs['state_year']
+        # year = self.kwargs['state_year']
 
-        if year:
-            context['stat'] = get_object_or_404(
-                StateStats, year__name=year, state=self.object)
-        else:
-            context['stat'] = get_object_or_404(
-                StateStats, year=SchoolYear.objects.first(),
-                state=self.object)
+        # if year:
+        #     context['stat'] = get_object_or_404(
+        #         StateStats, year__name=year, state=self.object)
+        # else:
+        context['stat'] = get_object_or_404(
+            StateStats, year=SchoolYear.objects.first(),
+            state=self.object)
 
         context['latest_state_cohort'] = state_cohorts.latest_cohort
 

--- a/scuole/stats/templatetags/stats_tags.py
+++ b/scuole/stats/templatetags/stats_tags.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.defaultfilters import floatformat
-from django.utils import six
+import six
 from django.utils.html import format_html
 
 register = template.Library()

--- a/scuole/templates/base.html
+++ b/scuole/templates/base.html
@@ -1,4 +1,4 @@
-<!doctype html>{% load i18n webpacker %}{% load static from staticfiles %}
+<!doctype html>{% load i18n webpacker %}{% load static %}
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/scuole/templates/campuses/campus_detail.html
+++ b/scuole/templates/campuses/campus_detail.html
@@ -1,4 +1,4 @@
-{% extends 'standard.html' %}{% load humanize i18n stats_tags journalize webpacker %}{% load static from staticfiles %}
+{% extends 'standard.html' %}{% load humanize i18n stats_tags journalize webpacker %}{% load static %}
 
 {% block meta %}{% include "includes/meta.html" with title=campus.name %}{% endblock meta %}
 

--- a/scuole/templates/cohorts_base.html
+++ b/scuole/templates/cohorts_base.html
@@ -1,4 +1,4 @@
-<!doctype html>{% load i18n %}{% load static from staticfiles %}
+<!doctype html>{% load i18n %}{% load static %}
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/scuole/templates/cohorts_landing.html
+++ b/scuole/templates/cohorts_landing.html
@@ -35,7 +35,7 @@
 
   <p class="landing-paragraph">Use this explorer to review and compare student outcomes by region or by county. Or, <a href="{% url 'cohorts:states' 'tx' %}">view outcomes at the statewide level</a>. You can also <a href="http://www.txhighereddata.org/index.cfm?objectId=4E600400-D970-11E8-BB650050560100A9">download the data</a>.</p>
 
-  <p class="landing-paragraph landing-paragraph--dateline">Last updated September 2020.</p>
+  <p class="landing-paragraph landing-paragraph--dateline">Last updated February 2021.</p>
 
   <p class="landing-paragraph landing-paragraph--credit">By <a href="http://www.texastribune.org/about/staff/ryan-murphy/">Ryan Murphy</a> and <a href="http://www.texastribune.org/about/staff/annie-daniel/">Annie Daniel</a></p>
 </section>

--- a/scuole/templates/cohorts_landing.html
+++ b/scuole/templates/cohorts_landing.html
@@ -1,4 +1,4 @@
-{% extends 'cohorts_base.html' %}{% load i18n humanize webpacker %}{% load static from staticfiles %}
+{% extends 'cohorts_base.html' %}{% load i18n humanize webpacker %}{% load static %}
 
 {% block meta %}{% include "includes/cohorts_meta.html" %}{% endblock meta %}
 

--- a/scuole/templates/cohorts_standard.html
+++ b/scuole/templates/cohorts_standard.html
@@ -1,4 +1,4 @@
-{% extends 'cohorts_base.html' %}{% load i18n webpacker %}{% load static from staticfiles %}
+{% extends 'cohorts_base.html' %}{% load i18n webpacker %}{% load static %}
 
 {% block header_class %}header header-standard{% endblock header_class %}
 

--- a/scuole/templates/districts/district_detail.html
+++ b/scuole/templates/districts/district_detail.html
@@ -1,4 +1,4 @@
-{% extends 'standard.html' %}{% load humanize i18n stats_tags journalize webpacker %}{% load static from staticfiles %}
+{% extends 'standard.html' %}{% load humanize i18n stats_tags journalize webpacker %}{% load static %}
 
 {% block meta %}{% include "includes/meta.html" with title=district.name %}{% endblock meta %}
 

--- a/scuole/templates/includes/cohorts_meta.html
+++ b/scuole/templates/includes/cohorts_meta.html
@@ -1,4 +1,4 @@
-<meta name="twitter:card" content="summary_large_image">{% load static from staticfiles %}
+<meta name="twitter:card" content="summary_large_image">{% load static %}
   <meta name="twitter:site" content="@texastribune">
   <meta name="twitter:creator" content="@texastribune">
   <meta property="og:url" content="https://schools.texastribune.org{{ request.path }}">

--- a/scuole/templates/includes/meta.html
+++ b/scuole/templates/includes/meta.html
@@ -1,4 +1,4 @@
-<meta name="twitter:card" content="summary_large_image">{% load static from staticfiles %}
+<meta name="twitter:card" content="summary_large_image">{% load static %}
   <meta name="twitter:site" content="@texastribune">
   <meta name="twitter:creator" content="@texastribune">
   <meta property="og:url" content="https://schools.texastribune.org{{ request.path }}">

--- a/scuole/templates/landing.html
+++ b/scuole/templates/landing.html
@@ -38,7 +38,7 @@
 
 <section class="landing-prose">
   <p class="landing-paragraph">Use our Texas public schools database to learn more about the state’s {{ district_count|intcomma }} districts and {{ campus_count|intcomma }} public schools, including hundreds of charter schools and alternative campuses. You can easily navigate through information on demographics, academic performance, college readiness and average teacher salaries for each school or&nbsp;district.</p>
-  <p class="landing-paragraph landing-paragraph--dateline">Last updated September 2020.</p>
+  <p class="landing-paragraph landing-paragraph--dateline">Last updated February 2021.</p>
   <p class="landing-paragraph landing-paragraph--credit">By <a href="http://www.texastribune.org/about/staff/ryan-murphy/">Ryan Murphy</a> and <a href="http://www.texastribune.org/about/staff/annie-daniel/">Annie Daniel</a></p>
 </section>
 

--- a/scuole/templates/landing.html
+++ b/scuole/templates/landing.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}{% load i18n humanize %}{% load static from staticfiles %}
+{% extends 'base.html' %}{% load i18n humanize %}{% load static %}
 
 {% block schema_type %}WebPage{% endblock schema_type %}
 

--- a/scuole/templates/standard.html
+++ b/scuole/templates/standard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}{% load i18n %}{% load static from staticfiles %}
+{% extends 'base.html' %}{% load i18n %}{% load static %}
 
 {% block header_class %}header header-standard{% endblock header_class %}
 

--- a/scuole/templates/states/state_detail.html
+++ b/scuole/templates/states/state_detail.html
@@ -1,4 +1,4 @@
-{% extends 'standard.html' %}{% load humanize i18n journalize webpacker %}{% load static from staticfiles %}
+{% extends 'standard.html' %}{% load humanize i18n journalize webpacker %}{% load static %}
 
 {% block meta %}{% include "includes/meta.html" with title=state.get_name_display %}{% endblock meta %}
 


### PR DESCRIPTION
Changes to accommodate package upgrades on the master branch (via dependabot). Some changes needed to be made to the Django templates and scripts.

One of these package upgrades involved bumping the Django version to 3.0.0. This bump involved:
- Switching from `{% load static from staticfiles %}` to `{% load static %}`, `staticfiles` was [removed in Django 3.0.0](https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library)
- `django.utils` in Django 3.0.0 [no longer includes](https://stackoverflow.com/questions/59193514/importerror-cannot-import-name-six-from-django-utils) `six`, so we install it separately and import it

Something worth looking more into: the `CampusDetailView` and `StateDetailView` were getting the `campus_year` and `state_year`, respectively, as url parameters — but after the Django upgrade, those lines of code failed.

In `StateDetailView`, I took out the logic grabbing the url parameter `state_year` for the state view because I wasn't sure why we have a `state_year` to begin with — all data is loaded based on the latest SchoolYear. Ditto for the `CampusDetailView`, unclear as to what `campus_year` is. It's not in our URL's.