### PR TITLE
changed @type schema type to WebPage for Parsely

### DIFF
--- a/scuole/templates/base.html
+++ b/scuole/templates/base.html
@@ -14,7 +14,7 @@
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",
-      "@type": "{% block schema_type %}NewsArticle{% endblock schema_type %}",
+      "@type": "{% block schema_type %}WebPage{% endblock schema_type %}",
       "headline": "{% block parsely_title %}Home{% endblock parsely_title %} (Public Schools)",
       "url": "https://schools.texastribune.org{{ request.path }}",
       "thumbnailUrl": "http://schools.texastribune.org{% static 'images/facebook-share.jpg' %}",

--- a/scuole/templates/cohorts_base.html
+++ b/scuole/templates/cohorts_base.html
@@ -14,7 +14,7 @@
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",
-      "@type": "{% block schema_type %}NewsArticle{% endblock schema_type %}",
+      "@type": "{% block schema_type %}WebPage{% endblock schema_type %}",
       "headline": "{% block parsely_title %}Home{% endblock parsely_title %} (Higher Ed Outcomes)",
       "url": "https://schools.texastribune.org{{ request.path }}",
       "thumbnailUrl": "http://schools.texastribune.org{% static 'images/cohorts-facebook-share.jpg' %}",


### PR DESCRIPTION
For Parse.ly purposes, I updated the @type schema in both `base.html` and `cohorts_base.html`. 