### PR TITLE
Configured to ignore Sentry "Disallowed Hosts" errors

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -142,6 +142,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 # https://docs.sentry.io/platforms/python/django/
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry.integrations.logging import ignore_logger
 
 ENABLE_SENTRY = True
 
@@ -150,6 +151,8 @@ sentry_sdk.init(
     integrations=[DjangoIntegration()],
     environment=env("SENTRY_ENVIRONMENT", "None")
 )
+
+ignore_logger("django.security.DisallowedHost")
 
 ############################
 # MIDDLEWARE CONFIGURATION #


### PR DESCRIPTION
We're getting a bunch Sentry errors of spam bots spamming the schools database. Because of ALLOWED_HOSTS setting, they're not successful however, it is sending Sentry "Disallowed Hosts" error alerts in an overwhelming amount. 

In case, we start to hit our Sentry quota and in order not to obfuscate real errors, I configured a fix so it will ignored all "Disallowed Hosts" errors. I followed instructions found [here](https://github.com/getsentry/sentry-python/issues/6).