### PR TITLE
Allow aws load balancer agent to make request without providing a header

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,8 +6,12 @@ server {
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+  if ($http_user_agent ~* "ELB-HealthChecker") {
+      return 301;
+    }
+
   # decline any non-texastribune host
-  if ($host !~* ^(.*\.texastribune\.org)$ ) {
+  if ($host !~* ^(.*\.texastribune\.org)$) {
       return 444;
     }
 

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,6 +6,7 @@ server {
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+  #Allow aws load balancer agent to make request without providing a header
   if ($http_user_agent ~* "ELB-HealthChecker") {
       return 301;
     }


### PR DESCRIPTION
# What does this PR do?
- This PR adds an ability to allow aws load balancer make a request without adding any host parameter.

# Why this PR?
-  The previous nginx PR #936 disallows any request that does not contain `subdomain.texastribune.org`. However, this blocks the aws load balancer as well. The load balancer then thinks this is a unhealthy host and the traffic would not flow to unhealthy host/server.  See images below.
   - ![image](https://github.com/texastribune/scuole/assets/119520346/17aaa3c9-c821-4077-879d-89d83fd5d10a)
   - ![image](https://github.com/texastribune/scuole/assets/119520346/e3d6daa3-4140-47e6-9e6b-ee387482eaa6)
   - ![image](https://github.com/texastribune/scuole/assets/119520346/d483c876-46c8-469e-af5f-5171066f81d5)

- To mitigate this, I am picking one that does not require app changes. I am allowing any request from ELB will be allowed regardless of host parameter.

## Why return 301?
- This is because (a) we are routing the traffic to the app (b) this is what the load balancer expects. In this case, we are directly returning the status code without going to the app. 
- See load balancer health check success code here
   - <img width="1440" alt="image" src="https://github.com/texastribune/scuole/assets/119520346/16d15d80-96c5-4e06-9f63-15e9211cf5bb">


## How do we know this works?
- I made changes in schools-prod-1 server and deployed the changes there. It started working properly. See images below.
   - This is a code change
      - <img width="755" alt="image" src="https://github.com/texastribune/scuole/assets/119520346/99b0e401-8959-4f71-8ab4-058078e82676">
   - This shows the traffic has started coming to this server
      - <img width="1440" alt="image" src="https://github.com/texastribune/scuole/assets/119520346/eb356c70-6991-41cc-954f-76634274a9ab">


# Any tech-debt?
- The school instances are very old!
- It is better to avoid 'if' clauses in nginx, but it seems we have been using them in many places including this PR 🤞!